### PR TITLE
feat: create paginated list screen using Compose and add mock data

### DIFF
--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/data/mock/MockCountryRepository.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/data/mock/MockCountryRepository.kt
@@ -1,0 +1,31 @@
+package br.dev.gustavovilela.firstprojectcompose.data.mock
+
+import br.dev.gustavovilela.firstprojectcompose.domain.model.Country
+import br.dev.gustavovilela.firstprojectcompose.domain.repository.ICountryRepository
+
+class MockCountryRepository : ICountryRepository {
+    override suspend fun getCountries(page: Int, pageSize: Int): List<Country> {
+        // Simulating a static list of countries for mocking purposes
+        val countries = listOf(
+            Country("Brazil", "Brasilia"),
+            Country("Canada", "Ottawa"),
+            Country("Germany", "Berlin"),
+            Country("Japan", "Tokyo"),
+            Country("Australia", "Canberra"),
+            Country("India", "New Delhi"),
+            Country("France", "Paris"),
+            Country("Italy", "Rome"),
+            Country("Mexico", "Mexico City"),
+            Country("Russia", "Moscow")
+        )
+        val start = (page - 1) * pageSize
+        val end = start + pageSize
+        if ( start >= countries.size) {
+            return  listOf()
+        }
+        return countries.subList(
+            start.coerceAtLeast(0),
+            end.coerceAtMost(countries.size)
+        )
+    }
+}

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/model/Country.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/model/Country.kt
@@ -1,0 +1,6 @@
+package br.dev.gustavovilela.firstprojectcompose.domain.model
+
+data class Country(
+    val name: String,
+    val capital: String
+)

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/repository/ICountryRepository.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/repository/ICountryRepository.kt
@@ -1,0 +1,7 @@
+package br.dev.gustavovilela.firstprojectcompose.domain.repository
+
+import br.dev.gustavovilela.firstprojectcompose.domain.model.Country
+
+interface ICountryRepository {
+    suspend fun getCountries(page: Int, pageSize: Int): List<Country>
+}

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/usecase/GetCountriesUseCase.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/domain/usecase/GetCountriesUseCase.kt
@@ -1,0 +1,10 @@
+package br.dev.gustavovilela.firstprojectcompose.domain.usecase
+
+import br.dev.gustavovilela.firstprojectcompose.domain.model.Country
+import br.dev.gustavovilela.firstprojectcompose.domain.repository.ICountryRepository
+
+class GetCountriesUseCase(private val repository: ICountryRepository) {
+    suspend fun execute(page: Int, pageSize: Int): List<Country> {
+        return repository.getCountries(page, pageSize)
+    }
+}

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/MainActivity.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/MainActivity.kt
@@ -12,9 +12,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import br.dev.gustavovilela.firstprojectcompose.data.mock.MockCountryRepository
+import br.dev.gustavovilela.firstprojectcompose.domain.usecase.GetCountriesUseCase
 import br.dev.gustavovilela.firstprojectcompose.presentation.component.CustomAppBar
 import br.dev.gustavovilela.firstprojectcompose.presentation.theme.FirstProjectComposeTheme
 import br.dev.gustavovilela.firstprojectcompose.presentation.ui.demo.DemoScreen
+import br.dev.gustavovilela.firstprojectcompose.presentation.ui.list.CountryListScreen
+import br.dev.gustavovilela.firstprojectcompose.presentation.ui.list.CountryListViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,6 +33,10 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     fun FirstScreen() {
+        val mock = MockCountryRepository()
+        val usecase = GetCountriesUseCase(repository = mock)
+        val viewmodel = CountryListViewModel(getCountriesUseCase = usecase)
+
         val currentContext = LocalContext.current
         Scaffold(
             topBar = {
@@ -39,7 +47,8 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.padding(padding),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    DemoScreen()
+//                    DemoScreen()
+                    CountryListScreen(viewModel = viewmodel)
                 }
             }
         )

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListScreen.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListScreen.kt
@@ -1,0 +1,80 @@
+package br.dev.gustavovilela.firstprojectcompose.presentation.ui.list
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import br.dev.gustavovilela.firstprojectcompose.data.mock.MockCountryRepository
+import br.dev.gustavovilela.firstprojectcompose.domain.model.Country
+import br.dev.gustavovilela.firstprojectcompose.domain.usecase.GetCountriesUseCase
+
+@Composable
+fun CountryListScreen(viewModel: CountryListViewModel) {
+    val countries = viewModel.countries.collectAsState().value
+    val isButtonVisisble by viewModel.isButtonVisible
+    val selectedCountry by viewModel.selectedCountry
+    val context: Context = LocalContext.current
+
+    selectedCountry?.let { country ->
+        Toast.makeText(context, "Clicked: ${country.name}", Toast.LENGTH_SHORT).show()
+        viewModel.resetCountrySelected()
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        LazyColumn {
+            items(countries) { country ->
+                CountryListItem(country, onItemClick = viewModel::onCountryClick)
+            }
+
+            item {
+                // Load more button to demonstrate infinite scrolling
+                if (isButtonVisisble) {
+                    Button(onClick = { viewModel.loadCountries() }) {
+                        Text("Load More")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CountryListItem(country: Country, onItemClick: (Country) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onItemClick(country) }
+            .padding(16.dp)
+    ) {
+        Text(text = country.name, style = MaterialTheme.typography.titleLarge)
+        Text(text = country.capital, style = MaterialTheme.typography.titleSmall)
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun CountryListScreenPreview() {
+    val mock = MockCountryRepository()
+    val usecase = GetCountriesUseCase(repository = mock)
+    val viewmodel = CountryListViewModel(getCountriesUseCase = usecase)
+    CountryListScreen(viewModel = viewmodel)
+}

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListViewModel.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListViewModel.kt
@@ -1,0 +1,55 @@
+package br.dev.gustavovilela.firstprojectcompose.presentation.ui.list
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import br.dev.gustavovilela.firstprojectcompose.domain.model.Country
+import br.dev.gustavovilela.firstprojectcompose.domain.usecase.GetCountriesUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class CountryListViewModel(private val getCountriesUseCase: GetCountriesUseCase) : ViewModel() {
+    private val _countries = MutableStateFlow<List<Country>>(emptyList())
+    val countries: StateFlow<List<Country>> = _countries.asStateFlow()
+
+    // State variable to control the visibility of the button
+    private val _isButtonVisible = mutableStateOf(true)
+    val isButtonVisible: State<Boolean> = _isButtonVisible
+
+    // State variable to hold the selected country
+    private var _selectedCountry by mutableStateOf<Country?>(null)
+    val selectedCountry: State<Country?> get() = mutableStateOf(_selectedCountry)
+
+    private var currentPage = 1
+    private val pageSize = 3
+
+    init {
+        loadCountries()
+    }
+
+    fun loadCountries() {
+        viewModelScope.launch {
+            val newCountries = getCountriesUseCase.execute(currentPage, pageSize)
+            if (newCountries.isEmpty()) {
+                _isButtonVisible.value = false
+            } else {
+                _countries.value = _countries.value + newCountries
+                currentPage++
+            }
+        }
+    }
+
+    // Function to handle item click
+    fun onCountryClick(country: Country) {
+        _selectedCountry = country
+    }
+
+    fun resetCountrySelected() {
+        _selectedCountry = null
+    }
+}

--- a/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListViewModelFactory.kt
+++ b/FirstProjectCompose/app/src/main/java/br/dev/gustavovilela/firstprojectcompose/presentation/ui/list/CountryListViewModelFactory.kt
@@ -1,0 +1,16 @@
+package br.dev.gustavovilela.firstprojectcompose.presentation.ui.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import br.dev.gustavovilela.firstprojectcompose.domain.usecase.GetCountriesUseCase
+
+class CountryListViewModelFactory(
+    private val getCountriesUseCase: GetCountriesUseCase
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CountryListViewModel::class.java)) {
+            return CountryListViewModel(getCountriesUseCase) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
## Description

This pull request introduces a new paginated list screen using Jetpack Compose and adds mock data to populate and display on the screen.

## Changes Made

- Implemented a new screen with a paginated list using Jetpack Compose.
- Added mock data to simulate real data and display on the new screen.
- Ensured the list is paginated to handle large datasets efficiently.